### PR TITLE
Add functionality for taking photo to upload with camera

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,7 +1,8 @@
 import React from 'react';
-import { StyleSheet, Text, View, Image } from 'react-native';
+import { StyleSheet, Text, View, Image, Button } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
 import * as Permissions from 'expo-permissions';
+import * as Camera from 'expo-camera';
 import * as Constants from 'expo-constants';
 
 export default class App extends React.Component {
@@ -13,7 +14,15 @@ export default class App extends React.Component {
     let { image } = this.state
     return (
       <View style={styles.container}>
-        <Text onPress={() => this.selectImg()}>Open up App.js to start working on your app!</Text>
+        <Text>PupDates</Text>
+        <Button 
+          onPress={() => this.selectImg()}
+          title="Add Photo"
+        />
+        <Button 
+          onPress={() => this.takeImg()}
+          title="Camera"
+        />
         {image &&
             <Image source={{ uri: image }} style={{ width: 200, height: 200 }} />}
       </View>
@@ -25,6 +34,16 @@ selectImg() {
     .then(response => {
       if (response.granted === true) {
         ImagePicker.launchImageLibraryAsync()
+          .then(response => this.setState({ image: response.uri }))
+      }
+    })
+  }
+
+takeImg() {
+  Camera.requestPermissionsAsync()
+    .then(response => {
+      if (response.granted === true) {
+        ImagePicker.launchCameraAsync()
           .then(response => this.setState({ image: response.uri }))
       }
     })

--- a/package-lock.json
+++ b/package-lock.json
@@ -2441,6 +2441,15 @@
         "url-parse": "^1.4.4"
       }
     },
+    "expo-camera": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/expo-camera/-/expo-camera-8.0.0.tgz",
+      "integrity": "sha512-mtP4NV2R4e+JTXUZBiA0ok4xSzTfRLxirvqJ5T7kjyozuCWUJeOhGk3hqNsBbWhwXDA+hirAge7169UB3vKfDQ==",
+      "requires": {
+        "lodash": "^4.6.0",
+        "prop-types": "^15.6.0"
+      }
+    },
     "expo-constants": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-8.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "react-native-gesture-handler": "^1.5.2",
     "react-native-web": "~0.11.7",
     "react-navigation": "^4.0.10",
-    "react-navigation-stack": "^1.10.3"
+    "react-navigation-stack": "^1.10.3",
+    "expo-camera": "~8.0.0"
   },
   "devDependencies": {
     "babel-preset-expo": "~8.0.0"


### PR DESCRIPTION
#### What's this PR do?
Add method for accessing camera when permission is granted
The method also stores the taken photo if confirmed
#### Where should the reviewer start?
On the takeImg method in App.js
#### How should this be manually tested?
Open the app on a mobile phone and attempt to open the camera using button click
Take photo and see that it displays on the app
#### What are the relevant tickets?
Issue #6 
