### PR TITLE
Create Slider box for dog images on home component

### DIFF
--- a/components/Home/Home.js
+++ b/components/Home/Home.js
@@ -44,7 +44,7 @@ class HomeScreen extends React.Component {
       'major-mono-display': require('../../assets/fonts/MajorMonoDisplay-Regular.ttf'),
     });
     const dogImages = await getDogImagesById(4)
-    this.setState({dogImages: dogImages.map( dog => dog.image_url)}, () =>  console.log(this.state.dogImages));
+    this.setState({dogImages: dogImages.map( dog => dog.image_url)});
   }
 
   render() {
@@ -56,7 +56,7 @@ class HomeScreen extends React.Component {
           <Text style={styles.packName}> Jordan's Pack </Text>
           <CardItem style={styles.imageCardContent}>
             <Body>
-            <SliderBox images={this.state.dogImages} style={styles.image} />
+            <SliderBox images={this.state.dogImages} style={styles.image} dotColor='rgb(21, 112, 125)'/>
               {/* <Image source={require('../../images/rose-human1pack.jpeg')} style={styles.image} /> */}
             </Body>
           </CardItem>

--- a/components/Home/Home.js
+++ b/components/Home/Home.js
@@ -25,7 +25,7 @@ class HomeScreen extends React.Component {
     headerTitle: () => <Image source={require('../../assets/PupDatesTitleSpread.png')} style={styles.navTitle}/>,
     headerRight: () => (
       <TouchableOpacity onPress={() => navigation.navigate('Menu')}>
-        <Ionicons name="ios-menu" size={50} color='rgb(21, 112, 125)'/>
+        <Ionicons name="ios-menu" size={50} color='rgb(21, 112, 125)' />
       </TouchableOpacity>
     ),
     headerStyle: {
@@ -56,8 +56,7 @@ class HomeScreen extends React.Component {
           <Text style={styles.packName}> Jordan's Pack </Text>
           <CardItem style={styles.imageCardContent}>
             <Body>
-            <SliderBox images={this.state.dogImages} style={styles.image} dotColor='rgb(21, 112, 125)'/>
-              {/* <Image source={require('../../images/rose-human1pack.jpeg')} style={styles.image} /> */}
+            <SliderBox images={this.state.dogImages} style={styles.image} dotColor='rgb(21, 112, 125)' circleLoop />
             </Body>
           </CardItem>
           <CardItem style={styles.imageCardContentText}>

--- a/components/Home/Home.js
+++ b/components/Home/Home.js
@@ -11,10 +11,13 @@ import {createAppContainer} from 'react-navigation';
 import { createStackNavigator } from 'react-navigation-stack';
 import { Container, Header, Content, Card, CardItem, Text, Body, Button } from 'native-base';
 import { Entypo } from '@expo/vector-icons';
+import { SliderBox } from "react-native-image-slider-box";
+import { getDogImagesById } from '../../apiCalls'
 
 class HomeScreen extends React.Component {
   state = {
-    image: null
+    image: null,
+    dogImages: []
   }
 
   static navigationOptions = ({navigation}) => ({
@@ -40,6 +43,8 @@ class HomeScreen extends React.Component {
    await Font.loadAsync({
       'major-mono-display': require('../../assets/fonts/MajorMonoDisplay-Regular.ttf'),
     });
+    const dogImages = await getDogImagesById(4)
+    this.setState({dogImages: dogImages.map( dog => dog.image_url)}, () =>  console.log(this.state.dogImages));
   }
 
   render() {
@@ -51,6 +56,7 @@ class HomeScreen extends React.Component {
           <Text style={styles.packName}> Jordan's Pack </Text>
           <CardItem style={styles.imageCardContent}>
             <Body>
+            <SliderBox images={this.state.dogImages} />
               <Image source={require('../../images/rose-human1pack.jpeg')} style={styles.image} />
             </Body>
           </CardItem>

--- a/components/Home/Home.js
+++ b/components/Home/Home.js
@@ -56,8 +56,8 @@ class HomeScreen extends React.Component {
           <Text style={styles.packName}> Jordan's Pack </Text>
           <CardItem style={styles.imageCardContent}>
             <Body>
-            <SliderBox images={this.state.dogImages} />
-              <Image source={require('../../images/rose-human1pack.jpeg')} style={styles.image} />
+            <SliderBox images={this.state.dogImages} style={styles.image} />
+              {/* <Image source={require('../../images/rose-human1pack.jpeg')} style={styles.image} /> */}
             </Body>
           </CardItem>
           <CardItem style={styles.imageCardContentText}>
@@ -155,7 +155,8 @@ leftNavIcon: {
     justifyContent: 'center',
     borderColor: 'black',
     borderWidth: 3.5,
-    borderRadius: 50
+    borderRadius: 50,
+    alignSelf: 'center'
   },
   infoText: {
     textAlign: 'left',

--- a/package-lock.json
+++ b/package-lock.json
@@ -6380,6 +6380,15 @@
         "prop-types": "^15.6.2"
       }
     },
+    "react-addons-shallow-compare": {
+      "version": "15.6.2",
+      "resolved": "https://registry.npmjs.org/react-addons-shallow-compare/-/react-addons-shallow-compare-15.6.2.tgz",
+      "integrity": "sha1-GYoAuR/DdiPbZKKP0XtZa6NicC8=",
+      "requires": {
+        "fbjs": "^0.8.4",
+        "object-assign": "^4.1.0"
+      }
+    },
     "react-devtools-core": {
       "version": "3.6.3",
       "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-3.6.3.tgz",
@@ -6623,6 +6632,14 @@
         }
       }
     },
+    "react-native-image-slider-box": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/react-native-image-slider-box/-/react-native-image-slider-box-1.0.11.tgz",
+      "integrity": "sha512-9mAXlacrmFHWkGsWLIqM66i8FxGkt2UnYi76BfpDYb9MVp/nMK8j2509pKTqvlyWDwWkzvct24hpFUJLLfdL3g==",
+      "requires": {
+        "react-native-snap-carousel": "*"
+      }
+    },
     "react-native-iphone-x-helper": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.2.1.tgz",
@@ -6658,6 +6675,15 @@
       "integrity": "sha512-tOxHGQUN83MTmQB4ghoQkibqOdGiX4JQEmeyEv96MKWO/x8T2PJv84ECUos9hD3blPRQwVwSpAid1PPPhrVEaw==",
       "requires": {
         "debounce": "^1.2.0"
+      }
+    },
+    "react-native-snap-carousel": {
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/react-native-snap-carousel/-/react-native-snap-carousel-3.8.4.tgz",
+      "integrity": "sha512-KMxLl75Tyf12DzeTCtV7xU0KuPZQQs/2+2iM90cgxcm3lrg4+hLXff5/61ynasBkzzJ5v4bTRq5CEy/qGUJVQw==",
+      "requires": {
+        "prop-types": "^15.6.1",
+        "react-addons-shallow-compare": "15.6.2"
       }
     },
     "react-native-vector-icons": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react-dom": "~16.9.0",
     "react-native": "https://github.com/expo/react-native/archive/sdk-36.0.0.tar.gz",
     "react-native-gesture-handler": "^1.5.2",
+    "react-native-image-slider-box": "^1.0.11",
     "react-native-web": "~0.11.7",
     "react-navigation": "^4.0.10",
     "react-navigation-stack": "^1.10.3"


### PR DESCRIPTION
#### What's this PR do?
Create a slider box view of images for the home/matches component.
#### Where should the reviewer start?
- I installed this package allowing easy integration integration and customization to any component:
https://www.npmjs.com/package/react-native-image-slider-box
- This is really easy to use all over the app in any component but putting this at the top with the rest of the imports: import { SliderBox } from "react-native-image-slider-box";
- All the images passed through has to be in an array and an image path(or url) as string
- Use in the component will look like this: <SliderBox images={[array of image strings]} />
#### How should this be manually tested?
Not Sure
#### Any background context you want to provide?
Being able to go through the different images is important in a known way for the user.
#### What are the relevant tickets?
#### Screenshots (if appropriate)
![PupDates Slide Images](https://user-images.githubusercontent.com/47948268/71565206-3655ac00-2a61-11ea-89fb-2e9641c3ba44.gif)
#### Questions:
